### PR TITLE
:ambulance: web_debranding: fix search_count method

### DIFF
--- a/access_apps/static/description/index.html
+++ b/access_apps/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/access_limit_records_number/static/description/index.html
+++ b/access_limit_records_number/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/access_restricted/static/description/index.html
+++ b/access_restricted/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/access_settings_menu/static/description/index.html
+++ b/access_settings_menu/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/auth_quick/static/description/index.html
+++ b/auth_quick/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/ir_rule_protected/static/description/index.html
+++ b/ir_rule_protected/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/portal_debranding/static/description/index.html
+++ b/portal_debranding/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/web_debranding/__manifest__.py
+++ b/web_debranding/__manifest__.py
@@ -9,7 +9,7 @@
 # License OPL-1 (https://www.odoo.com/documentation/user/14.0/legal/licenses/licenses.html#odoo-apps) for derivative work.
 {
     "name": "Backend debranding",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.1.2",
     "author": "IT-Projects LLC, Ivan Yelizariev",
     "license": "OPL-1",
     "category": "Debranding",

--- a/web_debranding/doc/changelog.rst
+++ b/web_debranding/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.1.2`
+--------
+
+- **Fix:** fix `search_count` method for `payment.acquirer`
+
 `1.1.1`
 --------
 

--- a/web_debranding/models/base.py
+++ b/web_debranding/models/base.py
@@ -29,6 +29,6 @@ class Base(models.AbstractModel):
     @api.model
     def search(self, domain, offset=0, limit=None, order=None, count=False):
         res = super().search(domain, offset, limit, order, count)
-        if self._name == "payment.acquirer":
+        if self._name == "payment.acquirer" and not count:
             res = res.filtered(lambda a: not a.module_to_buy)
         return res

--- a/web_debranding/static/description/index.html
+++ b/web_debranding/static/description/index.html
@@ -5,7 +5,7 @@
             <div class="">
                 <h2 class="display-3">Backend debranding</h2>
                 <h4 class="text-default">Build and enhance your Brand by removing references to <a href="https://www.odoo.com/"> odoo.com </a> and customizing company logo, favicon, page title, etc.</h4>
-                <p class="text-default mt16">Version: v<b>14.0</b>.1.1.1</p>
+                <p class="text-default mt16">Version: v<b>14.0</b>.1.1.2</p>
             </div>
         </div>
         <div class="col-md-3 text-right">
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:apps@itpp.dev">apps@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:apps@itpp.dev">apps@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/web_theme_kit/static/description/index.html
+++ b/web_theme_kit/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:apps@itpp.dev">apps@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:apps@itpp.dev">apps@itpp.dev</a>
             </p>
         </div>
     </div>

--- a/website_debranding/static/description/index.html
+++ b/website_debranding/static/description/index.html
@@ -13,7 +13,7 @@
                 <img src="https://itpp.dev/images/favicon.png"/>
                 <br/>Tested and maintained by
                 <br/><b>IT Projects Labs</b>
-                <br/>Assitance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
+                <br/>Assistance: <a href="mailto:help@itpp.dev">help@itpp.dev</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
The module inherits `base` to redefine search method for `payment.acquirer` (it could not be done directly because `payment` module may be not installed). However, the super may return integer if method is used as `search_count`. So, attempt to user `filtered` method would raise error.

Fix it by skiping `search_count`  case.