### PR TITLE
:ambulance: fix error on getting cr on hacking translation

### DIFF
--- a/web_debranding/__manifest__.py
+++ b/web_debranding/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 Ivan Yelizariev <https://twitter.com/yelizariev>
+# Copyright 2015-2023 Ivan Yelizariev <https://twitter.com/yelizariev>
 # Copyright 2017 Ilmir Karamov <https://it-projects.info/team/ilmir-k>
 # Copyright 2018-2019 Kolushov Alexandr <https://it-projects.info/team/KolushovAlexandr>
 # Copyright 2018 Ildar Nasyrov <https://it-projects.info/team/iledarn>
@@ -9,7 +9,7 @@
 # License OPL-1 (https://www.odoo.com/documentation/user/14.0/legal/licenses/licenses.html#odoo-apps) for derivative work.
 {
     "name": "Backend debranding",
-    "version": "16.0.2.0.1",
+    "version": "16.0.2.0.2",
     "author": "IT-Projects LLC, Ivan Yelizariev",
     "license": "OPL-1",
     "category": "Debranding",

--- a/web_debranding/doc/changelog.rst
+++ b/web_debranding/doc/changelog.rst
@@ -1,3 +1,9 @@
+`2.0.2`
+--------
+
+- **Fix:** fix error 'NoneType' object has no attribute 'cr'. It happens under following conditions: website module is installed and `--db-filter` is not set.
+
+
 `2.0.1`
 --------
 

--- a/web_debranding/translate.py
+++ b/web_debranding/translate.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Ivan Yelizariev <https://twitter.com/yelizariev>
+# Copyright 2022-2023 Ivan Yelizariev <https://twitter.com/yelizariev>
 # License OPL-1 (https://www.odoo.com/documentation/user/14.0/legal/licenses/licenses.html#odoo-apps)
 import inspect
 import logging
@@ -18,7 +18,10 @@ def _get_translation(self, source, module=None):
     source = _get_translation_original(source, module)
 
     frame = inspect.currentframe().f_back.f_back
-    (cr, dummy) = _._get_cr(frame, allow_create=False)
+    try:
+        (cr, dummy) = _._get_cr(frame, allow_create=False)
+    except AttributeError:
+        return source
     try:
         uid = self._get_uid(frame)
     except Exception:


### PR DESCRIPTION
Just ignore it, because it happens for translatable class attribute, which doesn't have Odoo reference

https://github.com/odoo/odoo/blob/777969774e24bc59651647ac3cf52dbdc16c702c/addons/website/controllers/form.py#L90